### PR TITLE
service: update SettingsService path

### DIFF
--- a/service/com.lge.settingsservice.json.prv
+++ b/service/com.lge.settingsservice.json.prv
@@ -1,6 +1,6 @@
 {
     "role": {
-        "exeName":"/usr/bin/SettingsService",
+        "exeName":"/usr/sbin/SettingsService",
         "type": "regular",
         "allowedNames": ["com.lge.settingsservice"]
     },

--- a/service/com.lge.settingsservice.json.pub
+++ b/service/com.lge.settingsservice.json.pub
@@ -1,6 +1,6 @@
 {
     "role": {
-        "exeName":"/usr/bin/SettingsService",
+        "exeName":"/usr/sbin/SettingsService",
         "type": "regular",
         "allowedNames": ["com.lge.settingsservice"]
     },

--- a/service/com.lge.settingsservice.service.prv
+++ b/service/com.lge.settingsservice.service.prv
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=com.lge.settingsservice
-Exec=/usr/bin/SettingsService
+Exec=/usr/sbin/SettingsService
 Type=static

--- a/service/com.lge.settingsservice.service.pub
+++ b/service/com.lge.settingsservice.service.pub
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=com.lge.settingsservice
-Exec=/usr/bin/SettingsService
+Exec=/usr/sbin/SettingsService
 Type=static


### PR DESCRIPTION
It's installed in /usr/sbin/ not /usr/bin/ so if you have to hardcode
some path, then at least hardcode the right one.

Should fix:
WARNING: do_rootfs: QA Issue: Unable to check the binary /usr/bin/SettingsService mentioned in LS2 role files